### PR TITLE
print_util can now handle numbers greater than 10 and reduce digits

### DIFF
--- a/src/eddington/print_util.py
+++ b/src/eddington/print_util.py
@@ -2,6 +2,8 @@
 import math
 from typing import Tuple
 
+import numpy as np
+
 from eddington.consts import DEFAULT_PRECISION
 
 
@@ -14,9 +16,10 @@ def to_precise_string(decimal: float, precision: int = DEFAULT_PRECISION) -> str
     :return: a string representing the decimal with given precision.
     """
     new_decimal, relevant_precision = __to_relevant_precision(decimal)
-    if relevant_precision < 3:
-        return f"{decimal:.{precision + relevant_precision}f}"
-    return f"{new_decimal:.{precision}f}e-0{relevant_precision}"
+    if -precision <= relevant_precision <= precision:
+        return f"{decimal:.{precision}f}"
+    sign = "-" if relevant_precision < 0 else "+"
+    return f"{new_decimal:.{precision}f}e{sign}{abs(relevant_precision)}"
 
 
 def __to_relevant_precision(decimal: float) -> Tuple[float, int]:
@@ -26,12 +29,15 @@ def __to_relevant_precision(decimal: float) -> Tuple[float, int]:
     :param decimal: a floating point number.
     :return: a tuple of a and n such that: decimal = a * 10^(-b).
     """
-    if decimal == 0:
-        return 0, 0
+    if decimal in [0, np.inf, np.nan, -np.inf]:
+        return decimal, 0
     precision = 0
     abs_a = math.fabs(decimal)
     while abs_a < 1.0:
         abs_a *= 10
+        precision -= 1
+    while abs_a >= 10.0:
+        abs_a /= 10
         precision += 1
     if decimal < 0:
         return -abs_a, precision

--- a/tests/plot/test_plot_fitting.py
+++ b/tests/plot/test_plot_fitting.py
@@ -17,7 +17,7 @@ A1, A2, A3 = np.array([1, 1]), np.array([3, 2]), np.array([3.924356, 1.2345e-5])
 A1_REPR, A2_REPR, A3_REPR = (
     "[a[0]=1.000, a[1]=1.000]",
     "[a[0]=3.000, a[1]=2.000]",
-    "[a[0]=3.924, a[1]=1.234e-05]",
+    "[a[0]=3.924, a[1]=1.234e-5]",
 )
 FIT_DATA = FittingData.random(FUNC, x=X, a=np.array([1, 2]), measurements=X.shape[0])
 TITLE_NAME = "Title"

--- a/tests/test_fitting_result.py
+++ b/tests/test_fitting_result.py
@@ -26,15 +26,15 @@ def case_standard():
 Initial parameters' values:
 \t1.0 3.0
 Fitted parameters' values:
-\ta[0] = 1.100 \u00B1 0.1000 (9.091% error)
-\ta[1] = 2.980 \u00B1 0.7600 (25.503% error)
+\ta[0] = 1.100 \u00B1 0.100 (9.091% error)
+\ta[1] = 2.980 \u00B1 0.760 (25.503% error)
 Fitted parameters covariance:
 [[0.01  2.3  ]
  [2.3   0.988]]
 Chi squared: 8.276
 Degrees of freedom: 5
 Chi squared reduced: 1.655
-P-probability: 0.1417
+P-probability: 0.142
 """
     fitting_result = FittingResult(**kwargs)
     return (
@@ -76,7 +76,7 @@ Fitted parameters covariance:
 Chi squared: 8.276
 Degrees of freedom: 5
 Chi squared reduced: 1.655
-P-probability: 0.1417
+P-probability: 0.142
 """
     fitting_result = FittingResult(**kwargs)
     return (
@@ -111,15 +111,15 @@ def case_with_zero_value():
 Initial parameters' values:
 \t1.0 3.0
 Fitted parameters' values:
-\ta[0] = 0.000 \u00B1 0.1000 (inf% error)
-\ta[1] = 0.000 \u00B1 0.7600 (inf% error)
+\ta[0] = 0.000 \u00B1 0.100 (inf% error)
+\ta[1] = 0.000 \u00B1 0.760 (inf% error)
 Fitted parameters covariance:
 [[0.01  2.3  ]
  [2.3   0.988]]
 Chi squared: 8.276
 Degrees of freedom: 5
 Chi squared reduced: 1.655
-P-probability: 0.1417
+P-probability: 0.142
 """
     fitting_result = FittingResult(**kwargs)
     return (
@@ -154,15 +154,15 @@ def case_with_small_p_probability():
 Initial parameters' values:
 \t1.0 3.0
 Fitted parameters' values:
-\ta[0] = 1.100 \u00B1 0.1000 (9.091% error)
-\ta[1] = 2.980 \u00B1 0.7600 (25.503% error)
+\ta[0] = 1.100 \u00B1 0.100 (9.091% error)
+\ta[1] = 2.980 \u00B1 0.760 (25.503% error)
 Fitted parameters covariance:
 [[0.01  2.3  ]
  [2.3   0.988]]
 Chi squared: 43.726
 Degrees of freedom: 5
 Chi squared reduced: 8.745
-P-probability: 2.633e-08
+P-probability: 2.633e-8
 """
     fitting_result = FittingResult(**kwargs)
     return (
@@ -247,9 +247,12 @@ def test_p_probability(expected, fitting_result):
 
 @parametrize_with_cases(argnames="expected, fitting_result", cases=THIS_MODULE)
 def test_representation(expected, fitting_result):
-    assert expected["repr_string"] == str(
-        fitting_result
-    ), "Representation is different than expected"
+    expected_repr = expected["repr_string"].split("\n")
+    actual_repr = str(fitting_result).split("\n")
+    for i, (expected_line, actual_line) in enumerate(zip(expected_repr, actual_repr)):
+        assert (
+            expected_line == actual_line
+        ), f"Representation is different than expected on line {i}"
 
 
 @parametrize_with_cases(argnames="expected, fitting_result", cases=THIS_MODULE)

--- a/tests/test_print_util.py
+++ b/tests/test_print_util.py
@@ -1,82 +1,83 @@
+import numpy as np
 from pytest_cases import THIS_MODULE, parametrize_with_cases
 
 from eddington.print_util import to_precise_string
 
 
-def case_int_with_2_zeroes():
-    inp = dict(a=14, n=2)
-    out = dict(relevant_precision=0, precise_string="14.00")
-    return inp, out
+def case_positive_int_add_zeros():
+    return 31, 2, "31.00"
 
 
-def case_int_with_4_zeroes():
-    inp = dict(a=3, n=4)
-    out = dict(relevant_precision=0, precise_string="3.0000")
-    return inp, out
+def case_big_positive_int_reduce_digits():
+    return 31415, 3, "3.141e+4"
 
 
-def case_negative_int_with_2_zeroes():
-    inp = dict(a=-14, n=2)
-    out = dict(relevant_precision=0, precise_string="-14.00")
-    return inp, out
+def case_small_positive_int_reduce_digits():
+    return 25.5033557, 3, "25.503"
 
 
-def case_one_with_3_zeroes():
-    inp = dict(a=1, n=3)
-    out = dict(relevant_precision=0, precise_string="1.000")
-    return inp, out
+def case_negative_int_add_zeros():
+    return -31, 2, "-31.00"
 
 
-def case_negative_one_with_3_zeroes():
-    inp = dict(a=-1, n=3)
-    out = dict(relevant_precision=0, precise_string="-1.000")
-    return inp, out
+def case_negative_int_reduce_digits():
+    return -31415, 3, "-3.141e+4"
 
 
-def case_zero_with_3_zeroes():
-    inp = dict(a=0, n=3)
-    out = dict(relevant_precision=0, precise_string="0.000")
-    return inp, out
+def case_one_adds_zeros():
+    return 1, 3, "1.000"
+
+
+def case_negative_one_add_zeros():
+    return -1, 3, "-1.000"
+
+
+def case_zero_add_zeros():
+    return 0.0, 3, "0.000"
+
+
+def case_minus_zero_add_zeros():
+    return -0.0, 3, "-0.000"
 
 
 def case_float_bigger_than_one_reduce_digits():
-    inp = dict(a=3.141592, n=2)
-    out = dict(relevant_precision=0, precise_string="3.14")
-    return inp, out
+    return np.pi, 2, "3.14"
 
 
 def case_float_bigger_than_one_add_zeroes():
-    inp = dict(a=3.52, n=5)
-    out = dict(relevant_precision=0, precise_string="3.52000")
-    return inp, out
+    return np.pi, 5, "3.14159"
 
 
 def case_float_smaller_than_one_reduce_digits():
-    inp = dict(a=0.3289, n=1)
-    out = dict(relevant_precision=1, precise_string="0.33")
-    return inp, out
+    return 0.712, 1, "0.7"
 
 
 def case_float_smaller_than_one_add_zeroes():
-    inp = dict(a=0.52, n=3)
-    out = dict(relevant_precision=1, precise_string="0.5200")
-    return inp, out
+    return 0.712, 4, "0.7120"
 
 
 def case_small_float_reduce_digits():
-    inp = dict(a=3.289e-5, n=1)
-    out = dict(relevant_precision=5, precise_string="3.3e-05")
-    return inp, out
+    return 3.289e-5, 1, "3.3e-5"
 
 
 def case_small_float_add_zeroes():
-    inp = dict(a=3.289e-5, n=4)
-    out = dict(relevant_precision=5, precise_string="3.2890e-05")
-    return inp, out
+    return 3.289e-5, 4, "3.2890e-5"
 
 
-@parametrize_with_cases(argnames="inp, out", cases=THIS_MODULE)
-def test_precise_string(inp, out):
+def case_infinity():
+    return np.inf, 3, "inf"
+
+
+def case_negative_infinity():
+    return -np.inf, 3, "-inf"
+
+
+def case_nan():
+    return np.nan, 3, "nan"
+
+
+@parametrize_with_cases(argnames=["a", "n", "string"], cases=THIS_MODULE)
+def test_precise_string(a, n, string):
     assert (
-        to_precise_string(inp["a"], inp["n"]) == out["precise_string"]
+        to_precise_string(a, precision=n) == string
     ), "Relevant precision is different than expected"


### PR DESCRIPTION
**Description**
print util now can reduce the number of digits of very large numbers. Now, we can turn `146732356` into `1.467e+8`

**Declaration**
Please declare the following:

- [X] I have read the CODE_OF_CONDUCT
- [X] I have read and followed the contribution guide in [here](https://eddington.readthedocs.io/en/latest/community/contribution_guide.html)