### PR TITLE
Fix memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 
 # IDE
 .idea/
+
+# Memory profile
+mprofile_*.dat

--- a/src/eddington/cli/fit.py
+++ b/src/eddington/cli/fit.py
@@ -109,8 +109,6 @@ def eddington_fit(
         should_plot_residuals=should_plot_residuals,
         x_log_scale=x_log_scale,
         y_log_scale=y_log_scale,
-        xlabel=x_label,
-        ylabel=y_label,
         grid=grid,
     )
 

--- a/src/eddington/cli/util.py
+++ b/src/eddington/cli/util.py
@@ -50,43 +50,44 @@ def fit_and_plot(  # pylint: disable=too-many-arguments,invalid-name
     x_label = data.x_column if x_label is None else x_label
     y_label = data.y_column if y_label is None else y_label
     if should_plot_data:
-        show_or_export(
-            plot_data(
-                data=data,
-                title_name=f"{func.title_name} - Data",
-                xlabel=x_label,
-                ylabel=y_label,
-                **plot_kwargs,
-            ),
-            output_path=__optional_path(output_dir, f"{func.name}_data.png"),
-        )
+        with plot_data(
+            data=data,
+            title_name=f"{func.title_name} - Data",
+            xlabel=x_label,
+            ylabel=y_label,
+            **plot_kwargs,
+        ) as fig:
+            show_or_export(
+                fig, output_path=__optional_path(output_dir, f"{func.name}_data.png")
+            )
     if should_plot_fitting:
-        show_or_export(
-            plot_fitting(
-                func=func,
-                data=data,
-                a=result.a,
-                title_name=f"{func.title_name}",
-                legend=legend,
-                xlabel=x_label,
-                ylabel=y_label,
-                **plot_kwargs,
-            ),
-            output_path=__optional_path(output_dir, f"{func.name}.png"),
-        )
+        with plot_fitting(
+            func=func,
+            data=data,
+            a=result.a,
+            title_name=f"{func.title_name}",
+            legend=legend,
+            xlabel=x_label,
+            ylabel=y_label,
+            **plot_kwargs,
+        ) as fig:
+            show_or_export(
+                fig, output_path=__optional_path(output_dir, f"{func.name}.png")
+            )
     if should_plot_residuals:
-        show_or_export(
-            plot_residuals(
-                func=func,
-                data=data,
-                a=result.a,
-                title_name=f"{func.title_name} - Residuals",
-                xlabel=x_label,
-                ylabel=y_label,
-                **plot_kwargs,
-            ),
-            output_path=__optional_path(output_dir, f"{func.name}_residuals.png"),
-        )
+        with plot_residuals(
+            func=func,
+            data=data,
+            a=result.a,
+            title_name=f"{func.title_name} - Residuals",
+            xlabel=x_label,
+            ylabel=y_label,
+            **plot_kwargs,
+        ) as fig:
+            show_or_export(
+                fig,
+                output_path=__optional_path(output_dir, f"{func.name}_residuals.png"),
+            )
 
 
 def extract_array_from_string(a0: Optional[str]):  # pylint: disable=invalid-name

--- a/src/eddington/plot.py
+++ b/src/eddington/plot.py
@@ -9,6 +9,21 @@ from eddington.fitting_data import FittingData
 from eddington.print_util import to_precise_string
 
 
+class Figure:
+    def __init__(self, fig):
+        self._actual_fig = fig
+
+    def __enter__(self):
+        return self
+
+    def __getattr__(self, item):
+        return getattr(self._actual_fig, item)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        plt.clf()
+        plt.close("all")
+
+
 def plot_residuals(  # pylint: disable=invalid-name,too-many-arguments
     func,
     data: FittingData,
@@ -211,7 +226,7 @@ def get_figure(  # pylint: disable=too-many-arguments
     add_grid(ax=ax, is_grid=grid)
     set_scales(ax=ax, is_x_log_scale=x_log_scale, is_y_log_scale=y_log_scale)
 
-    return ax, fig
+    return ax, Figure(fig)
 
 
 def title(ax: plt.Axes, title_name: Optional[str]):  # pylint: disable=invalid-name

--- a/src/eddington/plot.py
+++ b/src/eddington/plot.py
@@ -10,16 +10,26 @@ from eddington.print_util import to_precise_string
 
 
 class Figure:
+    """
+    Wraps matplotlib Figure class.
+
+    It releases the memory when the figure is not longer in use.
+    """
+
     def __init__(self, fig):
+        """Figure constructor."""
         self._actual_fig = fig
 
     def __enter__(self):
+        """Return self when entering as context."""
         return self
 
     def __getattr__(self, item):
+        """Get attributes from wrapped figure."""
         return getattr(self._actual_fig, item)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        """Clear memory on exit."""
         plt.clf()
         plt.close("all")
 

--- a/tests/plot/conftest.py
+++ b/tests/plot/conftest.py
@@ -10,3 +10,13 @@ def mock_figure(mocker):
 @fixture
 def mock_plt_show(mocker):
     return mocker.patch.object(plt, "show")
+
+
+@fixture
+def mock_plt_clf(mocker):
+    return mocker.patch.object(plt, "clf")
+
+
+@fixture
+def mock_plt_close(mocker):
+    return mocker.patch.object(plt, "close")

--- a/tests/plot/test_plot_data.py
+++ b/tests/plot/test_plot_data.py
@@ -9,7 +9,9 @@ EPSILON = 1e-5
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=[cases.case_plot_data])
 def test_plot_data_without_boundaries(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert_calls(
         ax.set_xlim, [([], dict(left=0.1)), ([], dict(right=10.9))], rel=EPSILON
@@ -19,7 +21,9 @@ def test_plot_data_without_boundaries(base_dict, plot_method, mock_figure):
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=[cases.case_plot_data])
 def test_plot_data_with_xmin(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, xmin=-10)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert_calls(
         ax.set_xlim, [([], dict(left=-10)), ([], dict(right=10.9))], rel=EPSILON
@@ -29,6 +33,8 @@ def test_plot_data_with_xmin(base_dict, plot_method, mock_figure):
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=[cases.case_plot_data])
 def test_plot_data_with_xmax(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, xmax=20)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert_calls(ax.set_xlim, [([], dict(left=0.1)), ([], dict(right=20))], rel=EPSILON)

--- a/tests/plot/test_plot_data.py
+++ b/tests/plot/test_plot_data.py
@@ -9,7 +9,7 @@ EPSILON = 1e-5
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=[cases.case_plot_data])
 def test_plot_data_without_boundaries(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert_calls(
         ax.set_xlim, [([], dict(left=0.1)), ([], dict(right=10.9))], rel=EPSILON
@@ -19,7 +19,7 @@ def test_plot_data_without_boundaries(base_dict, plot_method, mock_figure):
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=[cases.case_plot_data])
 def test_plot_data_with_xmin(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, xmin=-10)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert_calls(
         ax.set_xlim, [([], dict(left=-10)), ([], dict(right=10.9))], rel=EPSILON
@@ -29,6 +29,6 @@ def test_plot_data_with_xmin(base_dict, plot_method, mock_figure):
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=[cases.case_plot_data])
 def test_plot_data_with_xmax(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, xmax=20)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert_calls(ax.set_xlim, [([], dict(left=0.1)), ([], dict(right=20))], rel=EPSILON)

--- a/tests/plot/test_plot_fundamentals.py
+++ b/tests/plot/test_plot_fundamentals.py
@@ -10,7 +10,9 @@ from tests.util import assert_dict_equal
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=cases)
 def test_simple_plot(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     ax.set_title.assert_called_once_with(cases.TITLE_NAME)
     ax.set_xlabel.assert_not_called()
@@ -24,7 +26,9 @@ def test_simple_plot(base_dict, plot_method, mock_figure):
 def test_plot_with_xlabel(base_dict, plot_method, mock_figure):
     xlabel = "X Label"
     fig = plot_method(**base_dict, xlabel=xlabel)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     ax.set_xlabel.assert_called_once_with(xlabel)
 
@@ -33,7 +37,9 @@ def test_plot_with_xlabel(base_dict, plot_method, mock_figure):
 def test_plot_with_ylabel(base_dict, plot_method, mock_figure):
     ylabel = "Y Label"
     fig = plot_method(**base_dict, ylabel=ylabel)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     ax.set_ylabel.assert_called_once_with(ylabel)
 
@@ -41,7 +47,9 @@ def test_plot_with_ylabel(base_dict, plot_method, mock_figure):
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=cases)
 def test_plot_with_grid(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, grid=True)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     ax.grid.assert_called_once_with(True)
 
@@ -49,7 +57,9 @@ def test_plot_with_grid(base_dict, plot_method, mock_figure):
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=cases)
 def test_plot_with_x_log_scale(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, x_log_scale=True)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     ax.set_xscale.assert_called_once_with("log")
     ax.set_yscale.assert_not_called()
@@ -58,7 +68,9 @@ def test_plot_with_x_log_scale(base_dict, plot_method, mock_figure):
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=cases)
 def test_plot_with_y_log_scale(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, y_log_scale=True)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     ax.set_xscale.assert_not_called()
     ax.set_yscale.assert_called_once_with("log")
@@ -70,7 +82,9 @@ def test_plot_with_y_log_scale(base_dict, plot_method, mock_figure):
 )
 def test_error_bar(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert ax.errorbar.call_count == 1
     assert_dict_equal(

--- a/tests/plot/test_plot_fundamentals.py
+++ b/tests/plot/test_plot_fundamentals.py
@@ -10,7 +10,7 @@ from tests.util import assert_dict_equal
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=cases)
 def test_simple_plot(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     ax.set_title.assert_called_once_with(cases.TITLE_NAME)
     ax.set_xlabel.assert_not_called()
@@ -24,7 +24,7 @@ def test_simple_plot(base_dict, plot_method, mock_figure):
 def test_plot_with_xlabel(base_dict, plot_method, mock_figure):
     xlabel = "X Label"
     fig = plot_method(**base_dict, xlabel=xlabel)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     ax.set_xlabel.assert_called_once_with(xlabel)
 
@@ -33,7 +33,7 @@ def test_plot_with_xlabel(base_dict, plot_method, mock_figure):
 def test_plot_with_ylabel(base_dict, plot_method, mock_figure):
     ylabel = "Y Label"
     fig = plot_method(**base_dict, ylabel=ylabel)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     ax.set_ylabel.assert_called_once_with(ylabel)
 
@@ -41,7 +41,7 @@ def test_plot_with_ylabel(base_dict, plot_method, mock_figure):
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=cases)
 def test_plot_with_grid(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, grid=True)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     ax.grid.assert_called_once_with(True)
 
@@ -49,7 +49,7 @@ def test_plot_with_grid(base_dict, plot_method, mock_figure):
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=cases)
 def test_plot_with_x_log_scale(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, x_log_scale=True)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     ax.set_xscale.assert_called_once_with("log")
     ax.set_yscale.assert_not_called()
@@ -58,7 +58,7 @@ def test_plot_with_x_log_scale(base_dict, plot_method, mock_figure):
 @parametrize_with_cases(argnames="base_dict, plot_method", cases=cases)
 def test_plot_with_y_log_scale(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, y_log_scale=True)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     ax.set_xscale.assert_not_called()
     ax.set_yscale.assert_called_once_with("log")
@@ -70,7 +70,7 @@ def test_plot_with_y_log_scale(base_dict, plot_method, mock_figure):
 )
 def test_error_bar(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert ax.errorbar.call_count == 1
     assert_dict_equal(
@@ -88,13 +88,25 @@ def test_error_bar(base_dict, plot_method, mock_figure):
     )
 
 
-def test_show_or_export_without_output(mock_figure, mock_plt_show):
+@parametrize_with_cases(argnames="base_dict, plot_method", cases=cases)
+def test_plot_as_context(
+    base_dict, plot_method, mock_figure, mock_plt_clf, mock_plt_close
+):
+    output = "/path/to/output"
+    with plot_method(**base_dict) as fig:
+        fig.savefig(output)
+    mock_figure.savefig.assert_called_once_with(output)
+    mock_plt_clf.assert_called_once_with()
+    mock_plt_close.assert_called_once_with("all")
+
+
+def test_show_or_export_without_output(mock_plt_show):
     fig = Mock()
     show_or_export(fig, None)
     mock_plt_show.assert_called_once_with()
 
 
-def test_show_or_export_with_output(mock_figure):
+def test_show_or_export_with_output():
     output = "/path/to/output"
     fig = Mock()
     show_or_export(fig, output)

--- a/tests/plot/test_plot_residuals.py
+++ b/tests/plot/test_plot_residuals.py
@@ -11,7 +11,9 @@ EPSILON = 1e-5
 )
 def test_residuals_error_bar(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     y_residuals = cases.FIT_DATA.y - cases.FUNC(cases.A, cases.FIT_DATA.x)
     ax = mock_figure.add_subplot.return_value
     assert_calls(
@@ -39,7 +41,9 @@ def test_residuals_error_bar(base_dict, plot_method, mock_figure):
 )
 def test_plot_residuals_without_boundaries(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert_calls(
         ax.hlines, [([0], dict(xmin=0.1, xmax=10.9, linestyles="dashed"))], rel=EPSILON
@@ -51,7 +55,9 @@ def test_plot_residuals_without_boundaries(base_dict, plot_method, mock_figure):
 )
 def test_plot_residuals_with_xmin(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, xmin=-10)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert_calls(
         ax.hlines, [([0], dict(xmin=-10, xmax=10.9, linestyles="dashed"))], rel=EPSILON
@@ -63,7 +69,9 @@ def test_plot_residuals_with_xmin(base_dict, plot_method, mock_figure):
 )
 def test_plot_residuals_with_xmax(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, xmax=20)
-    assert fig._actual_fig == mock_figure, "Figure is different than expected"
+    assert (
+        fig._actual_fig == mock_figure  # pylint: disable=protected-access
+    ), "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert_calls(
         ax.hlines, [([0], dict(xmin=0.1, xmax=20, linestyles="dashed"))], rel=EPSILON

--- a/tests/plot/test_plot_residuals.py
+++ b/tests/plot/test_plot_residuals.py
@@ -11,7 +11,7 @@ EPSILON = 1e-5
 )
 def test_residuals_error_bar(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     y_residuals = cases.FIT_DATA.y - cases.FUNC(cases.A, cases.FIT_DATA.x)
     ax = mock_figure.add_subplot.return_value
     assert_calls(
@@ -39,7 +39,7 @@ def test_residuals_error_bar(base_dict, plot_method, mock_figure):
 )
 def test_plot_residuals_without_boundaries(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert_calls(
         ax.hlines, [([0], dict(xmin=0.1, xmax=10.9, linestyles="dashed"))], rel=EPSILON
@@ -51,7 +51,7 @@ def test_plot_residuals_without_boundaries(base_dict, plot_method, mock_figure):
 )
 def test_plot_residuals_with_xmin(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, xmin=-10)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert_calls(
         ax.hlines, [([0], dict(xmin=-10, xmax=10.9, linestyles="dashed"))], rel=EPSILON
@@ -63,7 +63,7 @@ def test_plot_residuals_with_xmin(base_dict, plot_method, mock_figure):
 )
 def test_plot_residuals_with_xmax(base_dict, plot_method, mock_figure):
     fig = plot_method(**base_dict, xmax=20)
-    assert fig == mock_figure, "Figure is different than expected"
+    assert fig._actual_fig == mock_figure, "Figure is different than expected"
     ax = mock_figure.add_subplot.return_value
     assert_calls(
         ax.hlines, [([0], dict(xmin=0.1, xmax=20, linestyles="dashed"))], rel=EPSILON


### PR DESCRIPTION
**Description**
Fixes #115

There was a memory leak caused by Matplotlib. Fixed it by running `plt.clf` and `plt.close()` after finished using a figure.

**Declaration**
Please declare the following:

- [X] I have read the CODE_OF_CONDUCT
- [X] I have read and followed the contribution guide in [here](https://eddington.readthedocs.io/en/latest/community/contribution_guide.html)