### PR TITLE
Eddington should not be able to read a data file with header duplication

### DIFF
--- a/src/eddington/exceptions.py
+++ b/src/eddington/exceptions.py
@@ -34,6 +34,14 @@ class FittingDataInvalidFile(FittingDataError):  # noqa: D101
     pass
 
 
+class FittingDataHeaderDuplication(FittingDataError):  # noqa: D101
+    def __init__(self, filepath, duplicate_headers):  # noqa: D107
+        super().__init__(
+            f'The following headers appear more than once in "{filepath}": '
+            f'{", ".join(duplicate_headers)}'
+        )
+
+
 class FittingDataInvalidFileSyntax(FittingDataInvalidFile):  # noqa: D101
     def __init__(
         self, filepath: Union[str, Path], sheet: Optional[str] = None

--- a/src/eddington/fitting_data.py
+++ b/src/eddington/fitting_data.py
@@ -1,4 +1,5 @@
 """Fitting data class insert the fitting algorithm."""
+import collections
 import csv
 import json
 from collections import OrderedDict, namedtuple
@@ -22,6 +23,7 @@ from eddington.exceptions import (
     FittingDataColumnIndexError,
     FittingDataColumnsLengthError,
     FittingDataColumnsSelectionError,
+    FittingDataHeaderDuplication,
     FittingDataInvalidFileSyntax,
     FittingDataSetError,
 )
@@ -575,6 +577,13 @@ class FittingData:  # pylint: disable=R0902,R0904
         else:
             headers = [str(i) for i in range(len(headers))]
             content = rows
+        duplicate_headers = [
+            item for item, count in collections.Counter(headers).items() if count > 1
+        ]
+        if len(duplicate_headers) != 0:
+            raise FittingDataHeaderDuplication(
+                filepath=file_name, duplicate_headers=duplicate_headers
+            )
         try:
             content = [list(map(float, row)) for row in content]
         except (ValueError, TypeError) as error:

--- a/tests/fitting_data/test_read_fitting_data_from_file.py
+++ b/tests/fitting_data/test_read_fitting_data_from_file.py
@@ -8,6 +8,7 @@ from mock import Mock, PropertyMock, mock_open, patch
 from pytest_cases import fixture_ref, parametrize
 
 from eddington import FittingData, FittingDataInvalidFileSyntax
+from eddington.exceptions import FittingDataHeaderDuplication
 from tests.fitting_data import COLUMNS, CONTENT, ROWS, VALUES
 
 DummyCell = namedtuple("DummyCell", "value")
@@ -159,6 +160,16 @@ def test_read_with_empty_header(read, mocks):
     mocks["row_setter"](mocks["reader"], rows)
 
     with pytest.raises(FittingDataInvalidFileSyntax):
+        read(FILE_PATH)
+
+
+@parametrize("read, mocks", [fixture_ref(read_csv), fixture_ref(read_excel)])
+def test_read_with_header_duplication(read, mocks):
+    rows = deepcopy(ROWS)
+    rows[0][0] = rows[0][1]
+    mocks["row_setter"](mocks["reader"], rows)
+
+    with pytest.raises(FittingDataHeaderDuplication):
         read(FILE_PATH)
 
 


### PR DESCRIPTION
fixes #121

**Description**
Eddington should raise an exception when reading a data file with headers duplication.

**Declaration**
Please declare the following:

- [X] I have read the CODE_OF_CONDUCT
- [X] I have read and followed the contribution guide in [here](https://eddington.readthedocs.io/en/latest/community/contribution_guide.html)