### PR TITLE
User can get fitting result as a json string

### DIFF
--- a/integration_tests/read_write/test_save_result.py
+++ b/integration_tests/read_write/test_save_result.py
@@ -16,9 +16,17 @@ def test_save_result_as_text(tmpdir):
 
     assert output_path.exists(), "Output text file was not written"
 
+    with open(output_path, mode="r") as fd:
+        content = "".join(fd.readlines())
+    assert FIT_RESULT.pretty_string == content
+
 
 def test_save_result_as_json(tmpdir):
     output_path = tmpdir / "fit_result.json"
     FIT_RESULT.save_json(output_path)
 
     assert output_path.exists(), "Output json file was not written"
+
+    with open(output_path, mode="r") as fd:
+        content = "".join(fd.readlines())
+    assert FIT_RESULT.json_string == content

--- a/src/eddington/fitting_result.py
+++ b/src/eddington/fitting_result.py
@@ -84,21 +84,7 @@ class FittingResult:  # pylint: disable=too-many-instance-attributes
         :type file_path: ``str`` or ``Path``
         """
         with open(file_path, mode="w") as output_file:
-            json.dump(
-                dict(
-                    a0=self.a0.tolist(),  # type: ignore
-                    a=self.a.tolist(),  # type: ignore
-                    aerr=self.aerr.tolist(),  # type: ignore
-                    arerr=self.arerr.tolist(),  # type: ignore
-                    acov=self.acov.tolist(),  # type: ignore
-                    degrees_of_freedom=self.degrees_of_freedom,
-                    chi2=self.chi2,
-                    chi2_reduced=self.chi2_reduced,
-                    p_probability=self.p_probability,
-                ),
-                output_file,
-                indent=1,
-            )
+            output_file.write(self.json_string)
 
     @property
     def pretty_string(self) -> str:
@@ -111,6 +97,29 @@ class FittingResult:  # pylint: disable=too-many-instance-attributes
         if self.__pretty_string is None:
             self.__pretty_string = self.__build_pretty_string()
         return self.__pretty_string
+
+    @property
+    def json_string(self):
+        """
+        Json representation string.
+
+        :return: self representing json string
+        :rtype: str
+        """
+        return json.dumps(
+            dict(
+                a0=self.a0.tolist(),  # type: ignore
+                a=self.a.tolist(),  # type: ignore
+                aerr=self.aerr.tolist(),  # type: ignore
+                arerr=self.arerr.tolist(),  # type: ignore
+                acov=self.acov.tolist(),  # type: ignore
+                degrees_of_freedom=self.degrees_of_freedom,
+                chi2=self.chi2,
+                chi2_reduced=self.chi2_reduced,
+                p_probability=self.p_probability,
+            ),
+            indent=1,
+        )
 
     def __repr__(self) -> str:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,8 @@ from eddington import FittingData, FittingFunctionsRegistry
 
 
 @fixture
-def json_dump_mock(mocker):
-    return mocker.patch("json.dump")
+def json_dumps_mock(mocker):
+    return mocker.patch("json.dumps")
 
 
 @fixture

--- a/tests/util.py
+++ b/tests/util.py
@@ -51,6 +51,8 @@ def assert_equal_item(value1, value2, rel):
         assert value1 == pytest.approx(
             value2, rel=rel
         ), f"{value1} should be the same as {value2}"
+    elif isinstance(value1, dict):
+        assert_dict_equal(value1, value2, rel=rel)
     else:
         assert value1 == value2, f"{value1} should be the same as {value2}"
 


### PR DESCRIPTION
**Description**
Now `FittingFunction` has a `json_string` property.
This allows the user to get the result as json without saving it to a file.

**Declaration**
Please declare the following:

- [X] I have read the CODE_OF_CONDUCT
- [X] I have read and followed the contribution guide in [here](https://eddington.readthedocs.io/en/latest/community/contribution_guide.html)