### PR TITLE
Fix residuals bug when not having error columns

### DIFF
--- a/src/eddington/cli/plot.py
+++ b/src/eddington/cli/plot.py
@@ -171,10 +171,10 @@ def plot_cli(
             residuals_data.records_indices = checkers_list
             add_errorbar(
                 ax=ax,
-                x=residuals_data.x,
-                y=residuals_data.y,
-                xerr=residuals_data.xerr,
-                yerr=residuals_data.yerr,
+                x=residuals_data.x,  # type: ignore
+                y=residuals_data.y,  # type: ignore
+                xerr=residuals_data.xerr,  # type: ignore
+                yerr=residuals_data.yerr,  # type: ignore
                 label=label,
                 color=color,
             )

--- a/src/eddington/plot.py
+++ b/src/eddington/plot.py
@@ -135,10 +135,10 @@ def plot_residuals(  # pylint: disable=invalid-name,too-many-arguments,too-many-
     residuals = data.residuals(fit_func=func, a=a)
     add_errorbar(
         ax=ax,
-        x=residuals.x[checkers_list],
-        xerr=residuals.xerr[checkers_list],
-        y=residuals.y[checkers_list],
-        yerr=residuals.yerr[checkers_list],
+        x=residuals.x[checkers_list],  # type: ignore
+        xerr=residuals.xerr[checkers_list],  # type: ignore
+        y=residuals.y[checkers_list],  # type: ignore
+        yerr=residuals.yerr[checkers_list],  # type: ignore
         color=color,
     )
     horizontal_line(ax=ax, xmin=xmin, xmax=xmax)

--- a/tests/fitting_data/test_residuals_fitting_data.py
+++ b/tests/fitting_data/test_residuals_fitting_data.py
@@ -1,24 +1,14 @@
 import numpy as np
 import pytest
-from pytest_cases import fixture, unpack_fixture
 
-from eddington import FittingData, linear
+from eddington import FittingData, FittingDataError, linear
 
-a = np.array([1, 2])
-
-
-@fixture
-def make_data():
-    data = FittingData.random(linear, a=a)
-    return data, data.residuals(linear, a)
+A = np.array([1, 2])
 
 
-data, residuals_data = unpack_fixture(  # pylint: disable=unbalanced-tuple-unpacking
-    "data, residuals_data", make_data
-)
-
-
-def test_columns_names(data, residuals_data):
+def test_residuals_data_columns_names():
+    data = FittingData.random(linear, a=A)
+    residuals_data = data.residuals(fit_func=linear, a=A)
     assert (
         data.x_column == residuals_data.x_column
     ), "X column name is different than expected."
@@ -33,8 +23,10 @@ def test_columns_names(data, residuals_data):
     ), "Y error column name is different than expected."
 
 
-def test_columns_values(data, residuals_data):
-    y_residuals = data.y - linear(a, data.x)
+def test_residuals_data_columns_values():
+    data = FittingData.random(linear, a=A)
+    residuals_data = data.residuals(fit_func=linear, a=A)
+    y_residuals = data.y - linear(A, data.x)
 
     assert data.x == pytest.approx(
         residuals_data.x
@@ -48,3 +40,61 @@ def test_columns_values(data, residuals_data):
     assert data.yerr == pytest.approx(
         residuals_data.yerr
     ), "Y error column is different than expected."
+
+
+def test_residuals_data_without_xerr_column():
+    data = FittingData.random(linear, a=A)
+    data.xerr_column = None
+    residuals_data = data.residuals(fit_func=linear, a=A)
+    y_residuals = data.y - linear(A, data.x)
+
+    assert data.x == pytest.approx(
+        residuals_data.x
+    ), "X column is different than expected."
+    assert data.xerr is None, "X error column should be None."
+    assert y_residuals == pytest.approx(
+        residuals_data.y
+    ), "Y column is different than expected."
+    assert data.yerr == pytest.approx(
+        residuals_data.yerr
+    ), "Y error column is different than expected."
+
+
+def test_residuals_data_without_yerr_column():
+    data = FittingData.random(linear, a=A)
+    data.yerr_column = None
+    residuals_data = data.residuals(fit_func=linear, a=A)
+    y_residuals = data.y - linear(A, data.x)
+
+    assert data.x == pytest.approx(
+        residuals_data.x
+    ), "X column is different than expected."
+    assert data.xerr == pytest.approx(
+        residuals_data.xerr
+    ), "X error column is different than expected."
+    assert y_residuals == pytest.approx(
+        residuals_data.y
+    ), "Y column is different than expected."
+    assert data.yerr is None, "Y error column should be None."
+
+
+def test_residuals_data_without_x_column():
+    data = FittingData.random(linear, a=A)
+    data.x_column = None
+
+    with pytest.raises(
+        FittingDataError,
+        match="^Could not calculate residuals data without x values.$",
+    ):
+        data.residuals(fit_func=linear, a=A)
+
+
+def test_residuals_data_without_y_column():
+    data = FittingData.random(linear, a=A)
+    data.y_column = None
+
+    with pytest.raises(
+        FittingDataError,
+        match="^Could not calculate residuals data without y values.$",
+    ):
+        data.residuals(fit_func=linear, a=A)


### PR DESCRIPTION
**Description**
Fix a bug that residuals data cannot handle x errors or y errors to be None.

**Declaration**
Please declare the following:

- [X] I have read the CODE_OF_CONDUCT
- [X] I have read and followed the contribution guide in [here](https://eddington.readthedocs.io/en/latest/community/contribution_guide.html)