### PR TITLE
Fix columns order in random FittingData

### DIFF
--- a/src/eddington/random_util.py
+++ b/src/eddington/random_util.py
@@ -80,20 +80,19 @@ def random_data(  # pylint: disable=invalid-name,too-many-arguments,too-many-loc
     else:
         measurements = x.shape[0]
     raw_data = OrderedDict()
+    actual_xerr, xerr = __generate_errors(
+        column_name=xerr_column, sigma=xsigma, measurements=measurements
+    )
+    actual_yerr, yerr = __generate_errors(
+        column_name=yerr_column, sigma=ysigma, measurements=measurements
+    )
+    y = fit_func(a, x + actual_xerr) + actual_yerr
     raw_data[x_column] = x
     if xerr_column is not None:
-        xerr = random_sigma(average_sigma=xsigma, size=measurements)
-        actual_xerr = random_error(scales=xerr)
         raw_data[xerr_column] = xerr
-    else:
-        actual_xerr = np.zeros(shape=x.shape)
+    raw_data[y_column] = y
     if yerr_column is not None:
-        yerr = random_sigma(average_sigma=ysigma, size=measurements)
-        actual_yerr = random_error(scales=yerr)
         raw_data[yerr_column] = yerr
-    else:
-        actual_yerr = np.zeros(shape=x.shape)
-    raw_data[y_column] = fit_func(a, x + actual_xerr) + actual_yerr
 
     return FittingData(
         data=raw_data,
@@ -136,3 +135,12 @@ def random_error(scales: np.ndarray) -> np.ndarray:
     :return: errors array.
     """
     return np.random.normal(scale=scales)
+
+
+def __generate_errors(column_name, sigma, measurements):
+    if column_name is not None:
+        average_error = random_sigma(average_sigma=sigma, size=measurements)
+        actual_xerr = random_error(scales=average_error)
+        return actual_xerr, average_error
+    actual_xerr = np.zeros(shape=measurements)
+    return actual_xerr, 0

--- a/tests/test_random_util.py
+++ b/tests/test_random_util.py
@@ -74,6 +74,9 @@ def assert_data_values(
     assert_numpy_array_equal(data.y, y, rel=EPSILON)
     assert_numpy_array_equal(data.yerr, yerr, rel=EPSILON)
 
+    columns = [x_column, xerr_column, y_column, yerr_column]
+    columns = [column for column in columns if column is not None]
+    assert data.all_columns == columns
     assert data.x_column == x_column
     assert data.xerr_column == xerr_column
     assert data.y_column == y_column


### PR DESCRIPTION
**Description**
The order of columns in random data should be x -> xerr -> y -> yerr.

**Declaration**
Please declare the following:

- [X] I have read the CODE_OF_CONDUCT
- [X] I have read and followed the contribution guide in [here](https://eddington.readthedocs.io/en/latest/community/contribution_guide.html)