### PR TITLE
Fix statue errors

### DIFF
--- a/src/eddington/fitting_data.py
+++ b/src/eddington/fitting_data.py
@@ -881,8 +881,11 @@ class FittingData:  # pylint: disable=R0902,R0904
         :type only_selected: bool
         :returns: Minimal interval containing column values
         :rtype: Interval
+        :raises ValueError: if column_name is None, raising Value error
         """
         values = self.column_data(column_name=column_name, only_selected=only_selected)
+        if values is None:
+            raise ValueError("Column must be specified correctly to get its domain.")
         return Interval(min_val=np.min(values), max_val=np.max(values))
 
     def statistics(self, column_name: str) -> Optional[Statistics]:

--- a/src/eddington/interval.py
+++ b/src/eddington/interval.py
@@ -416,10 +416,14 @@ class Interval:
         :return: Unification interval
         :rtype: Interval
         """
-        min_vals = [interval.min_val for interval in intervals]
-        max_vals = [interval.max_val for interval in intervals]
-        min_val = None if None in min_vals else np.min(min_vals)
-        max_val = None if None in max_vals else np.max(max_vals)
+        min_vals = [
+            interval.min_val for interval in intervals if interval.min_val is not None
+        ]
+        max_vals = [
+            interval.max_val for interval in intervals if interval.max_val is not None
+        ]
+        min_val = None if len(min_vals) < len(intervals) else np.min(min_vals)
+        max_val = None if len(max_vals) < len(intervals) else np.max(max_vals)
         return Interval(min_val=min_val, max_val=max_val)
 
     def __set_from_interval(self, other: "Interval"):

--- a/src/eddington/plot/figure_builder.py
+++ b/src/eddington/plot/figure_builder.py
@@ -4,9 +4,10 @@ from typing import Dict, List, Optional, Union
 
 import numpy as np
 
-from eddington import FittingData, FittingFunction
 from eddington.consts import DEFAULT_TICKS
 from eddington.exceptions import PlottingError
+from eddington.fitting_data import FittingData
+from eddington.fitting_function_class import FittingFunction
 from eddington.interval import Interval
 from eddington.plot.figure import Figure
 from eddington.plot.line_style import LineStyle

--- a/src/eddington/random_util.py
+++ b/src/eddington/random_util.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import numpy as np
 
-from eddington import FittingData
 from eddington.consts import (
     DEFAULT_MAX_COEFF,
     DEFAULT_MEASUREMENTS,
@@ -14,6 +13,7 @@ from eddington.consts import (
     DEFAULT_XSIGMA,
     DEFAULT_YSIGMA,
 )
+from eddington.fitting_data import FittingData
 
 
 def random_data(  # pylint: disable=invalid-name,too-many-arguments,too-many-locals

--- a/src/eddington/raw_data_builder.py
+++ b/src/eddington/raw_data_builder.py
@@ -2,7 +2,7 @@
 import collections
 from typing import List, Optional, Union
 
-from eddington import FittingDataInvalidFile
+from eddington.exceptions import FittingDataInvalidFile
 
 
 class RawDataBuilder:

--- a/statue.toml
+++ b/statue.toml
@@ -2,19 +2,42 @@
 parent = "standard"
 help = "Don't check duplications in pylint"
 
-[commands.pylint.no_duplicate]
-# This is a bummer...
-# Waiting for https://github.com/PyCQA/pylint/issues/748 to be resolved.
-add_args = ["--disable=duplicate-code"]
-
 [commands.flake8]
-args = ["--max-line-length=88", "--ignore=DAR"]
+args = [ "--max-line-length=88", "--ignore=DAR",]
+version = "4.0.1"
+
+[commands.pylint]
+version = "2.12.2"
+
+[commands.black]
+version = "21.12b0"
+
+[commands.isort]
+version = "5.10.1"
+
+[commands.mypy]
+version = "0.930"
+
+[commands.bandit]
+version = "1.7.1"
+
+[commands.pydocstyle]
+version = "6.1.1"
+
+[commands.darglint]
+version = "1.8.1"
+
+[commands.autoflake]
+version = "1.4"
 
 [sources.src]
-contexts = ["no_duplicate"]
+contexts = [ "no_duplicate",]
 
 [sources.tests]
-contexts = ["test"]
+contexts = [ "test",]
 
 [sources.integration_tests]
-contexts = ["test"]
+contexts = [ "test",]
+
+[commands.pylint.no_duplicate]
+add_args = [ "--disable=duplicate-code",]

--- a/tests/fitting_data/test_fitting_data_setters_and_getters.py
+++ b/tests/fitting_data/test_fitting_data_setters_and_getters.py
@@ -249,6 +249,14 @@ def test_get_column_domain_only_selected(header_name):
     assert_float_equal(domain.max_val, np.max(values), rel=EPSILON)
 
 
+def test_get_column_domain_of_none_raises_value_error():
+    fitting_data = FittingData(COLUMNS)
+    with pytest.raises(
+        ValueError, match="^Column must be specified correctly to get its domain.$"
+    ):
+        fitting_data.column_domain(None)
+
+
 @parametrize("header_name", COLUMNS_NAMES)
 def test_get_column_domain_all_records(header_name):
     fitting_data = FittingData(COLUMNS)

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -46,7 +46,7 @@ def test_all_interval_constructor():
 
 
 @parametrize(
-    argnames=["min_val", "max_val"],
+    argnames="min_val,max_val",
     argvalues=[
         (0, 10),
         (0, None),
@@ -62,7 +62,7 @@ def test_interval_unpacking(min_val, max_val):
 
 
 @parametrize(
-    argnames=["interval", "min_val", "result"],
+    argnames="interval,min_val,result",
     argvalues=[
         (Interval.all(), 3, Interval(3, None)),
         (Interval(0.5, 7), 2, Interval(2, 7)),
@@ -80,7 +80,7 @@ def test_interval_successful_set_minimum(interval, min_val, result):
 
 
 @parametrize(
-    argnames=["interval", "max_val", "result"],
+    argnames="interval,max_val,result",
     argvalues=[
         (Interval.all(), 3, Interval(None, 3)),
         (Interval(0.5, 7), 2, Interval(0.5, 2)),
@@ -98,7 +98,7 @@ def test_interval_successful_set_maximum(interval, max_val, result):
 
 
 @parametrize(
-    argnames=["interval", "size"],
+    argnames="interval,size",
     argvalues=[
         (Interval(0.5, 7), 6.5),
         (Interval.all(), None),
@@ -111,7 +111,7 @@ def test_interval_size(interval, size):
 
 
 @parametrize(
-    argnames=["interval", "value"],
+    argnames="interval,value",
     argvalues=[
         (Interval(0.5, 7), 3),
         (Interval(0.5, 7), 0.5),
@@ -130,7 +130,7 @@ def test_interval_contains(interval, value):
 
 
 @parametrize(
-    argnames=["interval", "value"],
+    argnames="interval,value",
     argvalues=[
         (Interval(0.5, 7), -3),
         (Interval(0.5, 7), 9),
@@ -143,7 +143,7 @@ def test_interval_not_contains(interval, value):
 
 
 @parametrize(
-    argnames=["smaller", "bigger"],
+    argnames="smaller,bigger",
     argvalues=[
         (Interval(2.5, 5), Interval(0.5, 7)),
         (Interval(2.5, 5), Interval(0.5, None)),
@@ -173,7 +173,7 @@ def test_intervals_gt_lt_relations(smaller, bigger):
 
 
 @parametrize(
-    argnames=["interval1", "interval2"],
+    argnames="interval1,interval2",
     argvalues=[
         (Interval(2.5, 5), Interval(2.5, 5)),
         (Interval(2.5, None), Interval(2.5, None)),
@@ -192,7 +192,7 @@ def test_interval_not_equal_to_tuple():
 
 
 @parametrize(
-    argnames=["interval", "val", "result"],
+    argnames="interval,val,result",
     argvalues=[
         (Interval(2.5, 5), 0, Interval(2.5, 5)),
         (Interval(2.5, 5), 1, Interval(3.5, 6)),
@@ -217,7 +217,7 @@ def test_intervals_add(interval, val, result):
 
 
 @parametrize(
-    argnames=["interval", "val", "result"],
+    argnames="interval,val,result",
     argvalues=[
         (Interval(2.5, 5), 0, Interval(2.5, 5)),
         (Interval(2.5, 5), 1, Interval(1.5, 4)),
@@ -241,7 +241,7 @@ def test_intervals_subtract(interval, val, result):
 
 
 @parametrize(
-    argnames=["interval", "val", "result"],
+    argnames="interval,val,result",
     argvalues=[
         (Interval(2.5, 5), 0, Interval(3.75, 3.75)),
         (Interval(2.5, 5), 1, Interval(2.5, 5)),
@@ -259,7 +259,7 @@ def test_intervals_multiply(interval, val, result):
 
 
 @parametrize(
-    argnames=["interval", "val", "result"],
+    argnames="interval,val,result",
     argvalues=[
         (Interval(2.5, 5), 1, Interval(2.5, 5)),
         (Interval(2.5, 5), 2, Interval(3.125, 4.375)),
@@ -275,7 +275,7 @@ def test_intervals_divide(interval, val, result):
 
 
 @parametrize(
-    argnames=["interval", "num", "ticks"],
+    argnames="interval,num,ticks",
     argvalues=[
         (Interval(0, 1), 2, np.array([0, 1])),
         (Interval(0, 1), 3, np.array([0, 0.5, 1])),
@@ -291,7 +291,7 @@ def test_intervals_ticks(interval, num, ticks):
 
 
 @parametrize(
-    argnames=["midpoint", "size", "result"],
+    argnames="midpoint,size,result",
     argvalues=[
         (2.5, 1, Interval(2, 3)),
         (2, 6, Interval(-1, 5)),
@@ -302,7 +302,7 @@ def test_neighbourhood_interval(midpoint, size, result):
 
 
 @parametrize(
-    argnames=["intervals", "result"],
+    argnames="intervals,result",
     argvalues=[
         ([Interval(2.5, 5)], Interval(2.5, 5)),
         ([Interval(2.5, 5), Interval(1.5, 4)], Interval(2.5, 4)),
@@ -321,7 +321,7 @@ def test_intervals_intersect(intervals, result):
 
 
 @parametrize(
-    argnames=["intervals", "result"],
+    argnames="intervals,result",
     argvalues=[
         ([Interval(2.5, 5)], Interval(2.5, 5)),
         ([Interval(2.5, 5), Interval(1.5, 4)], Interval(1.5, 5)),
@@ -411,7 +411,7 @@ def test_negative_ticks_num_failure():
 
 
 @parametrize(
-    argnames=["intervals"],
+    argnames="intervals",
     argvalues=[
         ([Interval(2.5, 5), Interval(6, 8)]),
         ([Interval(2.5, 5), Interval(1.5, 4), Interval(6, 8)]),

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,9 @@ commands =
     coverage report --fail-under=100
 
 [testenv:static]
-deps = statue
+deps =
+    statue
+    types-mock
 commands =
     statue run -i {posargs}
 


### PR DESCRIPTION
**Description**
In the new version of *Statue* (v0.0.17) one can specify specific versions of the commands to use as checkers.
In that way, when those commands release new versions, our CI process still passes.

In this PR I fixed the latest errors of the statue commands and fixated the latest versions.

**Declaration**
Please declare the following:

- [X] I have read the CODE_OF_CONDUCT
- [X] I have read and followed the contribution guide in [here](https://eddington.readthedocs.io/en/latest/community/contribution_guide.html)