### PR TITLE
Serialize fitting data

### DIFF
--- a/src/eddington/fitting_data.py
+++ b/src/eddington/fitting_data.py
@@ -260,7 +260,7 @@ class FittingData:  # pylint: disable=R0902,R0904
         :return: values of the x column
         :rtype: np.ndarray
         """
-        return self.column_data(self.x_column)
+        return self.__safe_column_data(self.x_column)
 
     @property
     def xerr(self) -> Optional[np.ndarray]:
@@ -270,7 +270,7 @@ class FittingData:  # pylint: disable=R0902,R0904
         :return: values of the x error column
         :rtype: np.ndarray
         """
-        return self.column_data(self.xerr_column)
+        return self.__safe_column_data(self.xerr_column)
 
     @property
     def y(self) -> Optional[np.ndarray]:
@@ -280,7 +280,7 @@ class FittingData:  # pylint: disable=R0902,R0904
         :return: values of the y column
         :rtype: np.ndarray
         """
-        return self.column_data(self.y_column)
+        return self.__safe_column_data(self.y_column)
 
     @property
     def yerr(self) -> Optional[np.ndarray]:
@@ -290,7 +290,7 @@ class FittingData:  # pylint: disable=R0902,R0904
         :return: values of the y error column
         :rtype: np.ndarray
         """
-        return self.column_data(self.yerr_column)
+        return self.__safe_column_data(self.yerr_column)
 
     @property
     def x_domain(self) -> Interval:
@@ -814,9 +814,7 @@ class FittingData:  # pylint: disable=R0902,R0904
 
     # Getter methods
 
-    def column_data(
-        self, column_name: Optional[str], only_selected: bool = True
-    ) -> Optional[np.ndarray]:
+    def column_data(self, column_name: str, only_selected: bool = True) -> np.ndarray:
         """
         Get the data of a column.
 
@@ -829,8 +827,6 @@ class FittingData:  # pylint: disable=R0902,R0904
         :returns: The data of the given column
         :rtype: numpy.ndarray or None
         """
-        if column_name is None:
-            return None
         self.__validate_column_name(column_name)
         values = self.data[column_name]
         if only_selected:
@@ -881,7 +877,9 @@ class FittingData:  # pylint: disable=R0902,R0904
         :rtype: Interval
         :raises ValueError: if column_name is None, raising Value error
         """
-        values = self.column_data(column_name=column_name, only_selected=only_selected)
+        values = self.__safe_column_data(
+            column_name=column_name, only_selected=only_selected
+        )
         if values is None:
             raise ValueError("Column must be specified correctly to get its domain.")
         return Interval(min_val=np.min(values), max_val=np.max(values))
@@ -1007,6 +1005,13 @@ class FittingData:  # pylint: disable=R0902,R0904
             self._statistics_map[column] = Statistics.from_array(
                 self.column_data(column)
             )
+
+    def __safe_column_data(
+        self, column_name: Optional[str], only_selected: bool = True
+    ) -> Optional[np.ndarray]:
+        if column_name is None:
+            return None
+        return self.column_data(column_name=column_name, only_selected=only_selected)
 
     def __get_column_index(self, column_name):
         if column_name is None:

--- a/src/eddington/fitting_data.py
+++ b/src/eddington/fitting_data.py
@@ -641,6 +641,31 @@ class FittingData:  # pylint: disable=R0902,R0904
         if index != self.yerr_index:
             self.yerr_index = index
 
+    def serialize(self) -> Dict[str, Any]:
+        """
+        Represent the data as serializable dictionary that can be saved as json.
+
+        :return: Fitting data as serializable dictionary
+        :rtype: Dict[str, Any]
+        """
+        serializable_data = OrderedDict(
+            [
+                (
+                    column,
+                    self.column_data(column_name=column, only_selected=False).tolist(),
+                )
+                for column in self.all_columns
+            ]
+        )
+        return OrderedDict(
+            data=serializable_data,
+            x_column=self.x_column,
+            xerr_column=self.xerr_column,
+            y_column=self.y_column,
+            yerr_column=self.yerr_column,
+            indices=list(self.records_indices),
+        )
+
     # More functionalities
 
     def residuals(self, fit_func, a: Union[List[float], np.ndarray]) -> "FittingData":
@@ -811,6 +836,29 @@ class FittingData:  # pylint: disable=R0902,R0904
             search=search,
         )
         # fmt: on
+
+    @classmethod
+    def deserialize(cls, serialized_data: Dict[str, Any]) -> "FittingData":
+        """
+        Deserialize a serialization dictionary into a fitting data.
+
+        This is the reverse function of `FittingData.serialize`
+
+        :param serialized_data: The serialize data to be deserializer
+        :type serialized_data: Dict[str, Any]
+        :return: Fitting functions
+        :rtype: FittingData
+        """
+        fitting_data = FittingData(
+            data=serialized_data["data"],
+            x_column=serialized_data["x_column"],
+            xerr_column=serialized_data["xerr_column"],
+            y_column=serialized_data["y_column"],
+            yerr_column=serialized_data["yerr_column"],
+            search=False,
+        )
+        fitting_data.records_indices = serialized_data["indices"]
+        return fitting_data
 
     # Getter methods
 

--- a/tests/fitting_data/test_fitting_data_serialize.py
+++ b/tests/fitting_data/test_fitting_data_serialize.py
@@ -1,0 +1,166 @@
+from collections import OrderedDict
+from typing import Any, Dict
+
+import numpy as np
+import pytest_cases
+from pytest_cases import THIS_MODULE
+
+from eddington import FittingData
+from tests.util import random_selected_records
+
+
+def random_raw_data(columns, size):
+    return {column: np.random.uniform(100, size=size).tolist() for column in columns}
+
+
+def case_simple_data_serialization():
+    columns = ["a", "b", "c", "d", "e", "f", "g"]
+    size = 10
+    raw_data = random_raw_data(columns=columns, size=size)
+    x_column, xerr_column, y_column, yerr_column = np.random.choice(
+        columns, size=4, replace=False
+    )
+    fitting_data = FittingData(
+        data=raw_data,
+        x_column=x_column,
+        xerr_column=xerr_column,
+        y_column=y_column,
+        yerr_column=yerr_column,
+    )
+    serialized_data = dict(
+        data=raw_data,
+        x_column=x_column,
+        xerr_column=xerr_column,
+        y_column=y_column,
+        yerr_column=yerr_column,
+        indices=[True] * size,
+    )
+    return fitting_data, serialized_data
+
+
+def case_data_serialization_with_selected_records():
+    columns = ["a", "b", "c", "d", "e", "f", "g"]
+    size = 10
+    raw_data = random_raw_data(columns=columns, size=size)
+    x_column, xerr_column, y_column, yerr_column = np.random.choice(
+        columns, size=4, replace=False
+    )
+    records_indices = random_selected_records(records_num=size)
+    fitting_data = FittingData(
+        data=raw_data,
+        x_column=x_column,
+        xerr_column=xerr_column,
+        y_column=y_column,
+        yerr_column=yerr_column,
+    )
+    fitting_data.records_indices = records_indices
+    serialized_data = dict(
+        data=raw_data,
+        x_column=x_column,
+        xerr_column=xerr_column,
+        y_column=y_column,
+        yerr_column=yerr_column,
+        indices=records_indices,
+    )
+    return fitting_data, serialized_data
+
+
+def case_data_serialization_with_no_xerr_column():
+    columns = ["a", "b", "c", "d", "e", "f", "g"]
+    size = 10
+    raw_data = random_raw_data(columns=columns, size=size)
+    x_column, y_column, yerr_column = np.random.choice(columns, size=3, replace=False)
+    fitting_data = FittingData(
+        data=raw_data,
+        x_column=x_column,
+        y_column=y_column,
+        yerr_column=yerr_column,
+        search=False,
+    )
+    serialized_data = dict(
+        data=raw_data,
+        x_column=x_column,
+        xerr_column=None,
+        y_column=y_column,
+        yerr_column=yerr_column,
+        indices=[True] * size,
+    )
+    return fitting_data, serialized_data
+
+
+def case_data_serialization_with_no_yerr_column():
+    columns = ["a", "b", "c", "d", "e", "f", "g"]
+    size = 10
+    raw_data = random_raw_data(columns=columns, size=size)
+    x_column, y_column, xerr_column = np.random.choice(columns, size=3, replace=False)
+    fitting_data = FittingData(
+        data=raw_data,
+        x_column=x_column,
+        y_column=y_column,
+        xerr_column=xerr_column,
+        search=False,
+    )
+    serialized_data = dict(
+        data=raw_data,
+        x_column=x_column,
+        xerr_column=xerr_column,
+        y_column=y_column,
+        yerr_column=None,
+        indices=[True] * size,
+    )
+    return fitting_data, serialized_data
+
+
+@pytest_cases.parametrize_with_cases(
+    argnames=["fitting_data", "serialized_data"], cases=THIS_MODULE
+)
+def test_serialize_fitting_data(
+    fitting_data: FittingData, serialized_data: Dict[str, Any]
+):
+    actual_serialized_data = fitting_data.serialize()
+    assert isinstance(actual_serialized_data, dict)
+    assert set(actual_serialized_data.keys()) == {
+        "data",
+        "x_column",
+        "y_column",
+        "xerr_column",
+        "yerr_column",
+        "indices",
+    }
+    actual_raw_data = actual_serialized_data["data"]
+    assert isinstance(actual_raw_data, OrderedDict)
+    assert list(actual_raw_data.keys()) == list(serialized_data["data"].keys())
+    for column in actual_serialized_data["data"].keys():
+        assert isinstance(actual_raw_data[column], list)
+        assert not isinstance(actual_raw_data[column], np.ndarray)
+        assert len(actual_raw_data[column]) == len(serialized_data["data"][column])
+        np.testing.assert_almost_equal(
+            actual_raw_data[column], serialized_data["data"][column]
+        )
+    assert actual_serialized_data["x_column"] == serialized_data["x_column"]
+    assert actual_serialized_data["xerr_column"] == serialized_data["xerr_column"]
+    assert actual_serialized_data["y_column"] == serialized_data["y_column"]
+    assert actual_serialized_data["yerr_column"] == serialized_data["yerr_column"]
+    assert actual_serialized_data["indices"] == serialized_data["indices"]
+
+
+@pytest_cases.parametrize_with_cases(
+    argnames=["fitting_data", "serialized_data"], cases=THIS_MODULE
+)
+def test_deserialize_fitting_data(
+    fitting_data: FittingData, serialized_data: Dict[str, Any]
+):
+    actual_fitting_data = FittingData.deserialize(serialized_data)
+    assert isinstance(actual_fitting_data, FittingData)
+    assert actual_fitting_data.number_of_records == fitting_data.number_of_records
+    assert actual_fitting_data.all_columns == fitting_data.all_columns
+    for column in fitting_data.all_columns:
+        np.testing.assert_almost_equal(
+            actual_fitting_data.column_data(column, only_selected=False),
+            fitting_data.column_data(column, only_selected=False),
+        )
+    assert actual_fitting_data.x_column == fitting_data.x_column
+    assert actual_fitting_data.xerr_column == fitting_data.xerr_column
+    assert actual_fitting_data.y_column == fitting_data.y_column
+    assert actual_fitting_data.yerr_column == fitting_data.yerr_column
+    assert actual_fitting_data.records_indices == fitting_data.records_indices


### PR DESCRIPTION
**Description**
Serialize `FittingData` to dictionary.  This serialized dictionary can be saved as json and toml, while `FittingData` cannot.

**Alternatives**
Not relevant.

**Additional context**
Python 3.10, Windows.

**Declaration**
Please declare the following:

- [X] I have read the CODE_OF_CONDUCT
- [X] I have read and followed the contribution guide in [here](https://eddington.readthedocs.io/en/latest/community/contribution_guide.html)